### PR TITLE
Prevent copying files when outputPath is set to null

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ For real-life example go to [examples](https://github.com/sheerun/babel-plugin-f
 
 Tells where to put static files. By default it's `"/public"`.
 
-This path is relative to the root of project.
+This path is relative to the root of project. Setting value `null` prevents the plugin to copy the file.
 
 ### publicPath
 

--- a/src/transform.js
+++ b/src/transform.js
@@ -108,7 +108,9 @@ export default (rootPath, filePath, opts) => {
       hash(filePath, hashType, digestType, parseInt(maxLength, 10))
   )
 
-  fs.copySync(filePath, path.join(rootPath, outputPath, url.split('?')[0]))
+  if (outputPath !== null) {
+    fs.copySync(filePath, path.join(rootPath, outputPath, url.split('?')[0]))
+  }
 
   return publicPath + '/' + url
 }

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -245,6 +245,15 @@ describe('index', function () {
     ).to.equal(true)
   })
 
+  it('doesnt output file when outputPath is null', function () {
+    transformCode(getFixtures('import-image.js'), { outputPath: null })
+    expect(
+      fs.existsSync(
+        path.resolve(__dirname, './public')
+      )
+    ).to.equal(false)
+  })
+
   it('outputs file in outputPath, nested', function () {
     const result = transformCode(getFixtures('import-image.js'), {
       name: '/foo/bar/[hash].[ext]'


### PR DESCRIPTION
I use this plugin in an environment where webpack copy the files already. In my case, only replacing with the proper url is needed.

Fix https://github.com/sheerun/babel-plugin-file-loader/issues/3