### PR TITLE
Add root path to options

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ For real-life example go to [examples](https://github.com/sheerun/babel-plugin-f
 
 ## Options
 
-### outputPath
+### rootPath 
 
 This is a relative or absolute path to use with `outputPath` to ensure files are copied to the correct location.
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ This is equivalent to following default configuration:
       {
         "name": "[hash].[ext]",
         "extensions": ["png", "jpg", "jpeg", "gif", "svg"],
+        "rootPath": "/root/path/to/app",
         "publicPath": "/public",
         "outputPath": "/public",
         "context": "",
@@ -68,6 +69,10 @@ const img2 = "/public/8d3fe267fe578005541.svg"
 For real-life example go to [examples](https://github.com/sheerun/babel-plugin-file-loader/tree/master/examples).
 
 ## Options
+
+### outputPath
+
+This is a relative or absolute path to use with `outputPath` to ensure files are copied to the correct location.
 
 ### outputPath
 

--- a/src/index.js
+++ b/src/index.js
@@ -22,7 +22,7 @@ const applyTransform = (p, t, state, value, calleeName) => {
 
   if (options.extensions && options.extensions.indexOf(ext.slice(1)) >= 0) {
     try {
-      const rootPath = state.file.opts.sourceRoot || process.cwd()
+      const rootPath = options.rootPath || state.file.opts.sourceRoot || process.cwd()
       const scriptDirectory = dirname(resolve(state.file.opts.filename))
       const filePath = resolve(scriptDirectory, value)
 


### PR DESCRIPTION
https://github.com/sheerun/babel-plugin-file-loader/issues/7

Fix for this issue.

```
babelRegister({
  cache: false,
  extensions: ['.js'],
  presets: [
    ['@babel/preset-env'],
    ['@babel/preset-react']
  ],
  plugins: [
    ['@babel/plugin-transform-runtime'],
    ['babel-plugin-transform-require-ignore', {
      extensions: ['.css', '.scss']
    }],
    ['babel-plugin-file-loader', {
      rootPath: '../',
      publicPath: '/dist',
      outputPath: '/public/dist'
    }]
  ]
})
```

Example usage with `@babel/register`