### PR TITLE
feat: allowing extension list to feature extensions with two dots (e.g. `module.less`, `module.css`)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-const { dirname, extname, resolve } = require('path')
+const { dirname, resolve } = require('path')
 const transform = require('./transform')
 
 const defaultOptions = {
@@ -17,10 +17,11 @@ const getVariableName = p => {
 }
 
 const applyTransform = (p, t, state, value, calleeName) => {
-  const ext = extname(value)
   const options = Object.assign({}, defaultOptions, state.opts)
 
-  if (options.extensions && options.extensions.indexOf(ext.slice(1)) >= 0) {
+  const valueMatches = options.extensions.some(ext => value.endsWith(ext))
+
+  if (options.extensions && valueMatches) {
     try {
       const rootPath = state.file.opts.sourceRoot || process.cwd()
       const scriptDirectory = dirname(resolve(state.file.opts.filename))

--- a/src/transform.js
+++ b/src/transform.js
@@ -82,9 +82,7 @@ function transform (rootPath, filePath, opts) {
 
   const parsed = path.parse(filePath)
 
-  if (parsed.ext) {
-    ext = parsed.ext.substr(1)
-  }
+  ext = parsed.base.slice(parsed.base.indexOf('.') + 1)
 
   let basePath
 

--- a/test/__snapshots__/index.test.js.snap
+++ b/test/__snapshots__/index.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`index doesnt inline file when the lenght equals the limit 1`] = `"const test = \\"/public/test/assets/file.txt\\";"`;
+exports[`index doesnt inline file when the length equals the limit 1`] = `"const test = \\"/public/test/assets/file.txt\\";"`;
 
 exports[`index handles base26 digest 1`] = `"const test = \\"/public/ccjesbcwzsppzgsqtbnioeblcexw.png\\";"`;
 
@@ -33,6 +33,8 @@ exports[`index handles full url as publicPath as query param 1`] = `"const test 
 exports[`index handles hash as query param 1`] = `"const test = \\"/public/test/assets/file.png?9c87cbf3\\";"`;
 
 exports[`index handles hex digest 1`] = `"const test = \\"/public/9c87cbf3ba33126ffd25ae7f2f6bbafb.png\\";"`;
+
+exports[`index handles multiple extensions 1`] = `"const test = \\"/static/934823cbc67ccf0d67aa2a2eeb798f12.module.less\\";"`;
 
 exports[`index handles name with custom hash length 1`] = `"const test = \\"/public/9c87cbf3.png\\";"`;
 

--- a/test/assets/file.module.less
+++ b/test/assets/file.module.less
@@ -1,0 +1,3 @@
+body {
+  background-color: red;
+}

--- a/test/fixtures/import-multiple.js
+++ b/test/fixtures/import-multiple.js
@@ -1,0 +1,1 @@
+import test from '../assets/file.module.less'

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -25,6 +25,14 @@ describe('index', function () {
     expect(result).toMatchSnapshot()
   })
 
+  it('handles multiple extensions', function () {
+    const result = transformCode(getFixtures('import-multiple.js'), {
+      publicPath: '/static',
+      extensions: ['module.less']
+    }).code
+    expect(result).toMatchSnapshot()
+  })
+
   it('handles custom import path with trailing slash', function () {
     const result = transformCode(getFixtures('import-image.js'), {
       publicPath: '/static/'
@@ -260,7 +268,7 @@ describe('index', function () {
     expect(fs.existsSync(path.resolve(__dirname, './public'))).toEqual(false)
   })
 
-  it('doesnt inline file when the lenght equals the limit', function () {
+  it('doesnt inline file when the length equals the limit', function () {
     const result = transformCode(getFixtures('import-text.js'), {
       extensions: ['txt'],
       name: '[path][name].[ext]',
@@ -269,7 +277,7 @@ describe('index', function () {
     expect(result).toMatchSnapshot()
   })
 
-  it('ouputs the file when the lenght equals the limit', function () {
+  it('ouputs the file when the length equals the limit', function () {
     transformCode(getFixtures('import-text.js'), {
       extensions: ['txt'],
       name: '[path][name].[ext]',


### PR DESCRIPTION
This PR should be able to allow people to use extensions with multiple `.`s in them.

This PR passes all tests, and should hopefully not break anyone's existing code. The one inconsistency is that if people have files extensions with multiple dots that *are* supposed to be excluded, these will now be included.

For this reason, I suggest a `minor` / `major` version.  